### PR TITLE
Add support for `// organize-imports-ignore` comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ const ts = require('typescript');
  * @param {import('prettier').Options} options
  */
 const organizeImports = (text, options) => {
+	if (text.includes('// organize-imports-ignore')) return text;
+
 	const fileName = options.filepath || 'file.ts';
 
 	const languageService = ts.createLanguageService(new ServiceHost(fileName, text));

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const ts = require('typescript');
  * @param {import('prettier').Options} options
  */
 const organizeImports = (text, options) => {
-	if (text.includes('// organize-imports-ignore') || text.includes('// tslint:disable:ordered-imports') {
+	if (text.includes('// organize-imports-ignore') || text.includes('// tslint:disable:ordered-imports')) {
 		return text;
 	}
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,9 @@ const ts = require('typescript');
  * @param {import('prettier').Options} options
  */
 const organizeImports = (text, options) => {
-	if (text.includes('// organize-imports-ignore')) return text;
+	if (text.includes('// organize-imports-ignore') || text.includes('// tslint:disable:ordered-imports') {
+		return text;
+	}
 
 	const fileName = options.filepath || 'file.ts';
 

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ _`prettier` and `typescript` are peer dependencies, so make sure you have those 
 
 The plugin will be loaded by Prettier automatically. No configuration needed.
 
-Files containing the substring `// organize-imports-ignore` are skipped.
+Files containing the substring `// organize-imports-ignore` or `// tslint:disable:ordered-imports` are skipped.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,8 @@ _`prettier` and `typescript` are peer dependencies, so make sure you have those 
 
 The plugin will be loaded by Prettier automatically. No configuration needed.
 
+Files containing the substring `// organize-imports-ignore` are skipped.
+
 ## License
 
 [MIT](/license).

--- a/test.js
+++ b/test.js
@@ -68,3 +68,16 @@ test('works without a filepath', (t) => {
 
 	t.is(formattedCode.split('\n')[0], 'import { bar, foo } from "foobar";');
 });
+
+test('files with `// organize-imports-ignore` are skipped', (t) => {
+	const code = `
+		// organize-imports-ignore
+		import { foo, bar } from "foobar"
+
+		export const foobar = foo + bar
+	`;
+
+	const formattedCode = prettify(code);
+
+	t.is(formattedCode.split('\n')[1], 'import { foo, bar } from "foobar";');
+});


### PR DESCRIPTION
[organize-imports-cli](https://github.com/thorn0/organize-imports-cli) supports it too.

Closes #4.