### PR TITLE
Add failing test for comments

### DIFF
--- a/test.js
+++ b/test.js
@@ -81,3 +81,15 @@ test('files with `// organize-imports-ignore` are skipped', (t) => {
 
 	t.is(formattedCode.split('\n')[1], 'import { foo, bar } from "foobar";');
 });
+
+test('maintain existing comments', (t) => {
+	const code = `    
+	// comment on top of line 1
+	import { foo, bar } from "foobar";
+	// comment on top of line 2
+	import baz from "baz";`;
+
+	const formattedCode = prettify(code);
+
+	t.is(code.split('\n').map(l => l.trim()).join('\n'), formattedCode)
+})


### PR DESCRIPTION
Comments are not being handled properly. 

In my code I got a comment repeated at the end of code block

input
```ts
import foo from 'foo';
// eslint-disable-next-line import/no-cycle
import bar from './bar';
```

Resulted int:

```ts
import foo from 'foo';
// eslint-disable-next-line import/no-cycle
import bar from './bar';
// eslint-disable-next-line import/no-cycle
```

Each formatting adds one more line:

```ts
import foo from 'foo';
// eslint-disable-next-line import/no-cycle
import bar from './bar';
// eslint-disable-next-line import/no-cycle
// eslint-disable-next-line import/no-cycle
```

