### PR TITLE
feat: support JS files and babel parsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const { parsers: babelParsers } = require('prettier/parser-babel');
 const { parsers: typescriptParsers } = require('prettier/parser-typescript');
 const ts = require('typescript');
 
@@ -90,11 +91,21 @@ class ServiceHost {
 	}
 }
 
-exports.parsers = {
-	typescript: {
-		...typescriptParsers.typescript,
-		preprocess: typescriptParsers.typescript.preprocess
-			? (text, options) => organizeImports(typescriptParsers.typescript.preprocess(text, options), options)
+/**
+ * Sets `organizeImports` as the given parsers preprocess step, or merges it with the existing one.
+ *
+ * @param {import('prettier').Parser} parser prettier parser
+ */
+const withOrganizeImportsPreprocess = (parser) => {
+	return {
+		...parser,
+		preprocess: parser.preprocess 
+			? (text, options) => organizeImports(parser.preprocess(text, options), options) 
 			: organizeImports,
-	},
+	}
+}
+
+exports.parsers = {
+	babel: withOrganizeImportsPreprocess(babelParsers.babel),
+	typescript: withOrganizeImportsPreprocess(typescriptParsers.typescript),
 };

--- a/index.js
+++ b/index.js
@@ -107,5 +107,6 @@ const withOrganizeImportsPreprocess = (parser) => {
 
 exports.parsers = {
 	babel: withOrganizeImportsPreprocess(babelParsers.babel),
+	'babel-ts': withOrganizeImportsPreprocess(babelParsers['babel-ts']),
 	typescript: withOrganizeImportsPreprocess(typescriptParsers.typescript),
 };

--- a/index.js
+++ b/index.js
@@ -56,6 +56,8 @@ class ServiceHost {
 			? ts.convertCompilerOptionsFromJson(ts.readConfigFile(tsconfig, ts.sys.readFile).config.compilerOptions).options
 			: ts.getDefaultCompilerOptions();
 
+		compilerOptions.allowJs = true;
+
 		this.name = name;
 		this.content = content;
 		this.options = compilerOptions;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "main": "index.js",
   "scripts": {
-    "test": "ava",
+    "test": "ava --verbose",
     "prepublishOnly": "npm test"
   },
   "files": [

--- a/test.js
+++ b/test.js
@@ -6,78 +6,83 @@ const prettier = require('prettier');
  * @param {string} code
  * @param {prettier.Options} options
  */
-const prettify = (code, options) =>
-	prettier.format(code, { filepath: 'file.ts', parser: 'typescript', plugins: ['.'], ...options });
+const prettify = (code, options) => prettier.format(code, { plugins: ['.'], filepath: 'file.ts', ...options });
 
-test('sorts imports', (t) => {
-	const code = `
-		import { foo, bar } from "foobar"
+const prettierOptions = [{ parser: 'babel' }, { parser: 'typescript' }];
 
-		export const foobar = foo + bar
-	`;
+prettierOptions.forEach((options) => {
+	const prefixTitle = (title) => `[${options.parser}] ${title}`;
 
-	const formattedCode = prettify(code);
+	test(prefixTitle('sorts imports'), (t) => {
+		const code = `
+			import { foo, bar } from "foobar"
+	
+			export const foobar = foo + bar
+		`;
 
-	t.is(formattedCode.split('\n')[0], 'import { bar, foo } from "foobar";');
-});
+		const formattedCode = prettify(code, options);
 
-test('removes partial unused imports', (t) => {
-	const code = `
-		import { foo, bar, baz } from "foobar";
+		t.is(formattedCode.split('\n')[0], 'import { bar, foo } from "foobar";');
+	});
 
-		const foobar = foo + baz
-	`;
+	test(prefixTitle('removes partial unused imports'), (t) => {
+		const code = `
+			import { foo, bar, baz } from "foobar";
+	
+			const foobar = foo + baz
+		`;
 
-	const formattedCode = prettify(code);
+		const formattedCode = prettify(code, options);
 
-	t.is(formattedCode.split('\n')[0], 'import { baz, foo } from "foobar";');
-});
+		t.is(formattedCode.split('\n')[0], 'import { baz, foo } from "foobar";');
+	});
 
-test('removes completely unused imports', (t) => {
-	const code = 'import { foo } from "foobar"';
+	test(prefixTitle('removes completely unused imports'), (t) => {
+		const code = 'import { foo } from "foobar"';
 
-	const formattedCode = prettify(code);
+		const formattedCode = prettify(code, options);
 
-	t.is(formattedCode, '');
-});
+		t.is(formattedCode, '');
+	});
 
-test('works with multi-line imports', (t) => {
-	const code = `
-		import {
-			foo,
-			bar,
-			baz,
-		} from "foobar";
+	test(prefixTitle('works with multi-line imports'), (t) => {
+		const code = `
+			import {
+				foo,
+				bar,
+				baz,
+			} from "foobar";
+	
+			console.log({ foo, bar, baz });
+		`;
 
-		console.log({ foo, bar, baz });
-	`;
+		const formattedCode = prettify(code, options);
 
-	const formattedCode = prettify(code);
+		t.is(formattedCode.split('\n')[0], 'import { bar, baz, foo } from "foobar";');
+	});
 
-	t.is(formattedCode.split('\n')[0], 'import { bar, baz, foo } from "foobar";');
-});
+	test(prefixTitle('works without a filepath'), (t) => {
+		const code = `
+			import { foo, bar } from "foobar"
+	
+			export const foobar = foo + bar
+		`;
 
-test('works without a filepath', (t) => {
-	const code = `
-		import { foo, bar } from "foobar"
+		const formattedCode = prettify(code, { ...options, filepath: undefined });
 
-		export const foobar = foo + bar
-	`;
+		t.is(formattedCode.split('\n')[0], 'import { bar, foo } from "foobar";');
+	});
 
-	const formattedCode = prettify(code, { filepath: undefined });
+	test(prefixTitle('files with `// organize-imports-ignore` are skipped'), (t) => {
+		const code = `
+			// organize-imports-ignore
+			import { foo, bar } from "foobar"
+	
+			export const foobar = foo + bar
+		`;
 
-	t.is(formattedCode.split('\n')[0], 'import { bar, foo } from "foobar";');
-});
+		const formattedCode = prettify(code, options);
 
-test('files with `// organize-imports-ignore` are skipped', (t) => {
-	const code = `
-		// organize-imports-ignore
-		import { foo, bar } from "foobar"
-
-		export const foobar = foo + bar
-	`;
-
-	const formattedCode = prettify(code);
-
-	t.is(formattedCode.split('\n')[1], 'import { foo, bar } from "foobar";');
+		t.is(formattedCode.split('\n')[1], 'import { foo, bar } from "foobar";');
+	});
 });

--- a/test.js
+++ b/test.js
@@ -8,7 +8,7 @@ const prettier = require('prettier');
  */
 const prettify = (code, options) => prettier.format(code, { plugins: ['.'], filepath: 'file.ts', ...options });
 
-const prettierOptions = [{ parser: 'babel' }, { parser: 'typescript' }];
+const prettierOptions = [{ parser: 'babel' }, { parser: 'babel-ts' }, { parser: 'typescript' }];
 
 prettierOptions.forEach((options) => {
 	const prefixTitle = (title) => `[${options.parser}] ${title}`;


### PR DESCRIPTION
Fixes https://github.com/simonhaenisch/prettier-plugin-organize-imports/issues/7.

Couldn't find any contribution guidelines or anything, so I've just tried to replicate the conventions and patterns I could see.

## Context
This feels like the best opinionated import sorter plugin for Prettier, but my team needs it to work with both JS and TS! It also doesn't work for TypeScript files when using the `babel-ts` parser at the moment.

I saw https://github.com/simonhaenisch/prettier-plugin-organize-imports/issues/7 and thought I'd take a stab. We've been using these changes locally for a while now and haven't had any issues 👍

## Changes

### Features
- adds support for JS files without a `tsconfig.json` by always treating `allowJs` as `true` (doesn't affect the actual import sorting, just enables it for JS files)
- allows organizing imports when using the `babel` and `babel-ts` parsers too

### Tests
- test suite now runs for a dynamic set of prettier options (only tests the supported parsers for now)