### PR TITLE
Rudimentary Svelte support

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,17 @@ const organizeImports = (code, options) => {
 			]);
 		}
 
+		//
+		/**
+		 * quick hack to organize individual script tags. auto-removal of imports
+		 * fails because each script tag will not detect usage of imports in other
+		 * script tags or template.
+		 * @todo manually parse svelte components to preserve context.
+		 */
+		if (filePath.endsWith('svelte')) {
+			return organize(code, 'file.ts');
+		}
+
 		return organize(code, filePath);
 	} catch (error) {
 		if (process.env.DEBUG) {
@@ -74,6 +85,16 @@ const withOrganizeImportsPreprocess = (parser) => {
 			organizeImports(parser.preprocess ? parser.preprocess(code, options) : code, options),
 	};
 };
+
+// quick hack to recognize and parse svelte components.
+exports.languages = [
+	{
+		name: 'svelte',
+		parsers: ['html'],
+		extensions: ['.svelte'],
+		vscodeLanguageIds: ['svelte'],
+	},
+];
 
 exports.parsers = {
 	babel: withOrganizeImportsPreprocess(babelParsers.babel),

--- a/test.js
+++ b/test.js
@@ -133,3 +133,76 @@ export default defineComponent({
 
 	t.is(formattedCode, code);
 });
+
+test('works with Svelte component and module scripts', (t) => {
+	const code = `<script context="module">
+  import   {writable,derived} from "svelte/store";
+  const firstName = writable("John");
+	const lastName = derived(firstName, ($firstName) => $firstName + " Doe");
+</script>
+
+<script>
+  import  {tick,onMount} from "svelte";
+  onMount(() => {
+    tick().then(() => {
+      console.log("Svelte component mounted");
+    });
+  });
+</script>
+
+<main>
+  <p>
+    {$firstName} {$lastName}
+  </p>
+</main>
+{#if $firstName}
+  <p>{$firstName}</p>
+{/if}
+
+<style>
+  main {
+		display: flex;
+  }
+</style>
+`;
+
+	const formattedCode = prettify(code, { filepath: 'file.svelte' });
+
+	t.is(formattedCode.split('\n')[1], `  import { derived, writable } from "svelte/store";`);
+	t.is(formattedCode.split('\n')[7], `  import { onMount, tick } from "svelte";`);
+});
+
+test('works with Svelte Typescript component and module scripts', (t) => {
+	const code = `<script lang="ts" context="module">
+  import   {writable,derived} from "svelte/store";
+  const firstName = writable("John");
+	const lastName = derived(firstName, ($firstName) => $firstName + " Doe");
+</script>
+
+<script lang="ts">
+  import  {tick,onMount} from "svelte";
+  onMount(() => {
+    tick().then(() => {
+      console.log("Svelte component mounted");
+    });
+  });
+</script>
+
+<main>
+  <p>
+    {$firstName} {$lastName}
+  </p>
+</main>
+
+<style>
+  main {
+		display: flex;
+  }
+</style>
+`;
+
+	const formattedCode = prettify(code, { filepath: 'file.svelte' });
+
+	t.is(formattedCode.split('\n')[1], `  import { derived, writable } from "svelte/store";`);
+	t.is(formattedCode.split('\n')[7], `  import { onMount, tick } from "svelte";`);
+});


### PR DESCRIPTION
A temporary solution to provide Svelte component support by parsing Svelte components as raw HTML, and organizing each script tag individially.

## Bugs

The biggest issue with this approach is that each script context has no awareness of other scripts and the Svelte template. Therefore, most imports will be treated as unused.

As such, this breaks unused imports. This improvement would only make sense if we can disable auto-removal of unused imports.

## Future improvements

The only full solution currently would be to manually parse Svelte components, but that is a major undertaking.