### PR TITLE
feat: expose option to skip destructive code actions

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,9 +44,25 @@ const withOrganizeImportsPreprocess = (parser) => {
 	};
 };
 
-exports.parsers = {
-	babel: withOrganizeImportsPreprocess(babelParsers.babel),
-	'babel-ts': withOrganizeImportsPreprocess(babelParsers['babel-ts']),
-	typescript: withOrganizeImportsPreprocess(typescriptParsers.typescript),
-	vue: withOrganizeImportsPreprocess(htmlParsers.vue),
+/**
+ * @type {import('prettier').Plugin}
+ */
+const plugin = {
+	options: {
+		organizeImportsSkipDestructiveCodeActions: {
+			type: 'boolean',
+			default: false,
+			category: 'OrganizeImports',
+			description: 'Skip destructive code actions like removing unused imports.',
+			since: '2.0.0',
+		},
+	},
+	parsers: {
+		babel: withOrganizeImportsPreprocess(babelParsers.babel),
+		'babel-ts': withOrganizeImportsPreprocess(babelParsers['babel-ts']),
+		typescript: withOrganizeImportsPreprocess(typescriptParsers.typescript),
+		vue: withOrganizeImportsPreprocess(htmlParsers.vue),
+	},
 };
+
+module.exports = plugin;

--- a/lib/organize.js
+++ b/lib/organize.js
@@ -7,7 +7,10 @@ const { getLanguageServiceHost, getVueLanguageServiceHost } = require('./service
  * @param {string} code
  * @param {import('prettier').ParserOptions} options
  */
-module.exports.organize = (code, { filepath = 'file.ts', parentParser, parser }) => {
+module.exports.organize = (
+	code,
+	{ filepath = 'file.ts', organizeImportsSkipDestructiveCodeActions, parentParser, parser },
+) => {
 	if (parentParser === 'vue') {
 		return code; // we do the preprocessing from the `vue` parent parser instead, so we skip the child parsers
 	}
@@ -23,7 +26,11 @@ module.exports.organize = (code, { filepath = 'file.ts', parentParser, parser })
 		languageService = require('typescript').createLanguageService(getLanguageServiceHost(filepath, code));
 	}
 
-	const fileChanges = languageService.organizeImports({ type: 'file', fileName: filepath }, {}, {})[0];
+	const fileChanges = languageService.organizeImports(
+		{ type: 'file', fileName: filepath, skipDestructiveCodeActions: organizeImportsSkipDestructiveCodeActions },
+		{},
+		{},
+	)[0];
 
 	return fileChanges ? applyTextChanges(code, fileChanges.textChanges) : code;
 };

--- a/prettier.d.ts
+++ b/prettier.d.ts
@@ -1,0 +1,8 @@
+export declare module 'prettier' {
+	interface Options {
+		organizeImportsSkipDestructiveCodeActions?: boolean;
+	}
+	interface ParserOptions {
+		organizeImportsSkipDestructiveCodeActions?: boolean;
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,17 @@ The plugin will be loaded by Prettier automatically. No configuration needed.
 
 Files containing the substring `// organize-imports-ignore` or `// tslint:disable:ordered-imports` are skipped.
 
+If you don't want destructive code actions (like removing unused imports), you can enable the option `organizeImportsSkipDestructiveCodeActions` via your Prettier config.
+
+```js
+// prettierrc.js
+
+module.exports = {
+  // ...
+  organizeImportsSkipDestructiveCodeActions: true,
+};
+```
+
 **Notes:**
 
 - Automatic plugin discovery is not supported with some package managers (e. g. [Yarn 2](https://github.com/prettier/prettier/issues/8474)). Check the [Prettier documentation](https://prettier.io/docs/en/plugins.html) for alternatives to manually load plugins in that case.

--- a/test.js
+++ b/test.js
@@ -166,3 +166,12 @@ import { NDivider } from "naive-ui";
 
 	t.is(formattedCode, code);
 });
+
+test('does not remove unused imports with `organizeImportsSkipDestructiveCodeActions` enabled', (t) => {
+	const code = `import { foo } from "./bar";
+`;
+
+	const formattedCode = prettify(code, { organizeImportsSkipDestructiveCodeActions: true });
+
+	t.is(formattedCode, code);
+});


### PR DESCRIPTION
Adds a new plugin option `organizeImportsSkipDestructiveCodeActions` that if set, runs `organizeImports` with the `skipDestructiveCodeActions` option enabled. This prevents unused imports from being removed.

Closes #37.