### PR TITLE
feat: add basic support for Svelte files

### DIFF
--- a/lib/organize.js
+++ b/lib/organize.js
@@ -23,6 +23,10 @@ module.exports.organize = (
 	if (parser === 'vue') {
 		languageService = require('@volar/vue-typescript').createLanguageService(getVueLanguageServiceHost(filepath, code));
 	} else {
+		if (parentParser === 'svelte') {
+			filepath += '.ts';
+			organizeImportsSkipDestructiveCodeActions = true;
+		}
 		languageService = require('typescript').createLanguageService(getLanguageServiceHost(filepath, code));
 	}
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "prettier-plugin",
     "typescript",
     "imports",
-    "organize-imports"
+    "organize-imports",
+    "vue",
+    "svelte"
   ],
   "main": "index.js",
   "scripts": {
@@ -25,10 +27,14 @@
   "peerDependencies": {
     "@volar/vue-typescript": ">=0.39.0",
     "prettier": ">=2.0",
+    "prettier-plugin-svelte": ">=2.0",
     "typescript": ">=2.9"
   },
   "peerDependenciesMeta": {
     "@volar/vue-typescript": {
+      "optional": true
+    },
+    "prettier-plugin-svelte": {
       "optional": true
     }
   },
@@ -37,6 +43,8 @@
     "@volar/vue-typescript": "0.39.5",
     "ava": "3.15.0",
     "prettier": "2.7.1",
+    "prettier-plugin-svelte": "2.7.0",
+    "svelte": "3.49.0",
     "typescript": "4.7.4"
   },
   "prettier": {

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ A plugin that makes Prettier organize your imports (i. e. sorts, combines and re
 **Features**
 
 - 👌 Dependency-free (just peer-dependencies you probably already have).
-- 💪 Supports `.js`, `.jsx`, `.ts`, `.tsx` and `.vue` files.
+- 💪 Supports `.js`, `.jsx`, `.ts`, `.tsx`, `.vue`, and `.svelte` files.
 - 🚀 Zero config.
 - 🤓 No more weird diffs or annoying merge conflicts in PRs caused by import statements.
 - 🤯 If your editor supports auto-imports, you'll stop thinking about your imports so much that you won't even care about their order anymore.
@@ -58,6 +58,16 @@ npm i --save-dev @volar/vue-typescript
 ```
 
 If you're using Vue.js with Pug templates, you'll also need to install `@volar/pug-language-service` as a dev dependency.
+
+### Svelte
+
+Make sure that you have the optional peer dependency `prettier-plugin-svelte` installed.
+
+```
+npm i --save-dev prettier-plugin-svelte
+```
+
+Note that `organizeImportsSkipDestructiveCodeActions` will be force-enabled because the plugin is currently unable to detect unused imports correctly.
 
 ### Debug Logs
 

--- a/test.js
+++ b/test.js
@@ -175,3 +175,26 @@ test('does not remove unused imports with `organizeImportsSkipDestructiveCodeAct
 
 	t.is(formattedCode, code);
 });
+
+test('has basic Svelte support', (t) => {
+	const code = `
+	<script lang="ts">
+		import Foo from './foo';
+		import Bar from './bar';
+	</script>
+
+	<Foo />
+	`;
+
+	const expectedCode = `<script lang="ts">
+  import Bar from "./bar";
+  import Foo from "./foo";
+</script>
+
+<Foo />
+`;
+
+	const formattedCode = prettify(code, { filepath: 'file.svelte' });
+
+	t.is(formattedCode, expectedCode);
+});


### PR DESCRIPTION
This is the only somewhat working solution I could come up with to close #39 for now, basically relying on `prettier-plugin-svelte` to extract the script content and then preprocessing that, but skipping destructive code actions because we can't know which imports are really unused without the full context of the `.svelte` file (e. g. component imports used in the template only).

I think this'll need more test cases though, because this approach was pretty broken with Vue, because Prettier has a [bug](https://github.com/prettier/prettier/issues/11206) with the `preprocess` hook when called in a child parser, which caused broken code around comments and other things (need to check the closed issues for specifics).
