### PR TITLE
Fix path comparation failuer on Windows

### DIFF
--- a/lib/service-host.js
+++ b/lib/service-host.js
@@ -28,7 +28,7 @@ const getLanguageServiceHost = (path, content) => {
 		getScriptFileNames: () => [path],
 		getScriptVersion: () => '0',
 		getScriptSnapshot: (filePath) => {
-			if (filePath === path) {
+			if (filePath === path.replace(/\\/g, '/')) {
 				return ts.ScriptSnapshot.fromString(content);
 			}
 		},


### PR DESCRIPTION
On Windows, Both `\` and `/` are used as path separators. If `filePath` is `src/index.ts` and `path` is `src\index.ts`, then `filePath === path` is `false`.

On Linux, `\` can be used for normal filenames, so it may be better not to use just a simple replacement. If there is a better canonicalization method, I will change to use that.