### PR TITLE
fix: prevent removing imports if a rangeEnd is passed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/index.js
+++ b/index.js
@@ -19,6 +19,12 @@ const organizeImports = (code, options) => {
 		return code;
 	}
 
+	// If rangeEnd is passed, the import might be considered unused if isn't contained in the range.
+	// Don't remove imports if rangeEnd is passed.
+	if (code.length !== options.rangeEnd) {
+		options.organizeImportsSkipDestructiveCodeActions = true;
+	}
+
 	try {
 		return organize(code, options);
 	} catch (error) {

--- a/index.js
+++ b/index.js
@@ -19,10 +19,13 @@ const organizeImports = (code, options) => {
 		return code;
 	}
 
-	// If rangeEnd is passed, the import might be considered unused if isn't contained in the range.
-	// Don't remove imports if rangeEnd is passed.
-	if (code.length !== options.rangeEnd) {
-		options.organizeImportsSkipDestructiveCodeActions = true;
+	const isRange =
+		Boolean(options.originalText) ||
+		options.rangeStart !== 0 ||
+		(options.rangeEnd !== Infinity && options.rangeEnd !== code.length);
+
+	if (isRange) {
+		return code; // processing a range doesn't make sense
 	}
 
 	try {

--- a/test/main.js
+++ b/test/main.js
@@ -70,6 +70,25 @@ test(
 	{ transformer: (res) => res.split('\n')[1] },
 );
 
+// In previous version, this test would fail because rangeEnd would cause the plugin to see the import as unused and remove it
+test('formats imports but does not remove them when rangeEnd is passed', async (t) => {
+	const code = `
+		import { foo, bar } from "foobar"
+
+		export const foobar = foo + bar
+	`;
+
+	const expectedFormattedCode = `
+		import { bar, foo } from "foobar";
+
+		export const foobar = foo + bar
+	`;
+
+	const formattedCode = await prettify(code, { rangeEnd: 10 });
+
+	t.is(formattedCode, expectedFormattedCode);
+});
+
 test('does not remove unused imports with `organizeImportsSkipDestructiveCodeActions` enabled', async (t) => {
 	const code = `import { foo } from "./bar";
 `;

--- a/test/main.js
+++ b/test/main.js
@@ -70,23 +70,14 @@ test(
 	{ transformer: (res) => res.split('\n')[1] },
 );
 
-// In previous version, this test would fail because rangeEnd would cause the plugin to see the import as unused and remove it
-test('formats imports but does not remove them when rangeEnd is passed', async (t) => {
-	const code = `
-		import { foo, bar } from "foobar"
+test('skips when formatting a range', async (t) => {
+	const code = 'import { foo } from "./bar";';
 
-		export const foobar = foo + bar
-	`;
+	const formattedCode1 = await prettify(code, { rangeEnd: 10 });
+	const formattedCode2 = await prettify(code, { rangeStart: 10 });
 
-	const expectedFormattedCode = `
-		import { bar, foo } from "foobar";
-
-		export const foobar = foo + bar
-	`;
-
-	const formattedCode = await prettify(code, { rangeEnd: 10 });
-
-	t.is(formattedCode, expectedFormattedCode);
+	t.is(formattedCode1, code);
+	t.is(formattedCode2, code);
 });
 
 test('does not remove unused imports with `organizeImportsSkipDestructiveCodeActions` enabled', async (t) => {


### PR DESCRIPTION
This prevents destructive operations when a `rangeEnd` is passed.

Prior to this, if `rangeEnd` was passed, the imports would be removed because the plugin considered them unused.

This should solve a bug experienced in JetBrains IDEs https://youtrack.jetbrains.com/issue/WEB-50178/Code-reformat-with-prettier-and-prettier-plugin-organize-imports-deletes-imports-if-Optimize-imports-is-enabled

Closes #110