### PR TITLE
fix: support vue-tsc v2.1

### DIFF
--- a/lib/get-language-service.js
+++ b/lib/get-language-service.js
@@ -62,11 +62,9 @@ function getVueDecoratedProxyLanguageService(langaugeServiceHost, languageServic
 
 	const vueLanguagePlugin = createVueLanguagePlugin(
 		ts,
-		(s) => s,
-		() => '',
-		() => false,
 		langaugeServiceHost.getCompilationSettings(),
 		tsconfig ? createParsedCommandLine(ts, ts.sys, tsconfig).vueOptions : resolveVueCompilerOptions({}),
+		(s) => s,
 	);
 
 	const language = createLanguage([vueLanguagePlugin], new FileMap(ts.sys.useCaseSensitiveFileNames), () => {});

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@types/node": "20.14.9",
-    "@vue/language-plugin-pug": "2.0.24",
+    "@vue/language-plugin-pug": "2.1.6",
     "ava": "6.1.3",
     "prettier": "3.3.2",
     "typescript": "5.5.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "peerDependencies": {
     "prettier": ">=2.0",
     "typescript": ">=2.9",
-    "vue-tsc": "^2.0.24"
+    "vue-tsc": "^2.1.0"
   },
   "peerDependenciesMeta": {
     "vue-tsc": {
@@ -40,7 +40,7 @@
     "ava": "6.1.3",
     "prettier": "3.3.2",
     "typescript": "5.5.2",
-    "vue-tsc": "2.0.24"
+    "vue-tsc": "^2.1.6"
   },
   "prettier": {
     "printWidth": 120,


### PR DESCRIPTION
fix #135
This is caused by a change in the `createVueLanguagePlugin` argument in `@vue/language-core`.