### PR TITLE
Add tests for comments inside imports

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -67,6 +67,42 @@ for (const macro of macros) {
 		'import { foo, bar } from "foobar";',
 		{ transformer: (res) => res.split('\n')[1] },
 	);
+	test(
+		'leaves commented imports intact',
+		macro,
+		`
+			// import { foo, bar } from "foobar"
+
+			export const foobar = foo + bar
+		`,
+		'// import { foo, bar } from "foobar"',
+	);
+	test(
+		'leaves comments in borders of multiline imports intact',
+		macro,
+		`
+import {
+	// DataGrid,
+	GridCellParams,
+	GridColDef,
+	GridLinkOperator,
+	GridRenderCellParams,
+	// plPL,
+} from "@mui/x-data-grid";
+
+DataGrid; GridCellParams; GridColDef; GridLinkOperator; GridRenderCellParams; plPL;
+		`,
+		`import {
+  // DataGrid,
+  GridCellParams,
+  GridColDef,
+  GridLinkOperator,
+  GridRenderCellParams,
+  // plPL,
+} from "@mui/x-data-grid";`
+		,
+		{ transformer: (res) => res.split('\n').slice(0, 8).join('\n') },
+	);
 }
 
 test('skips when formatting a range', async (t) => {


### PR DESCRIPTION
I added some tests to reproduce a problem with the plugin that I have currently (and to extend the test suite)

the last macro test that I added fails atm and it shouldn't be - that needs some fix, I wrote down the issue in #144 

![image](https://github.com/user-attachments/assets/1129b57f-fa05-40d3-8f8a-ef8b93a3b5b0)
