### PR TITLE
feat: `organizeImportsTypeOrder`

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,6 +70,25 @@ const plugin = {
 			category: 'OrganizeImports',
 			description: 'Skip destructive code actions like removing unused imports.',
 		},
+		organizeImportsTypeOrder: {
+			type: 'choice',
+			choices: [
+				{
+					value: 'last',
+					description: 'Places type imports last.',
+				},
+				{
+					value: 'first',
+					description: 'Places type imports first.',
+				},
+				{
+					value: 'inline',
+					description: 'Keeps type imports in place.',
+				},
+			],
+			category: 'OrganizeImports',
+			description: 'How to sort type imports when mixed in an import statement.',
+		},
 	},
 	parsers: {
 		babel: withOrganizeImportsPreprocess(babelParsers.babel),

--- a/lib/organize.js
+++ b/lib/organize.js
@@ -10,7 +10,7 @@ const { getLanguageService } = require('./get-language-service');
  */
 module.exports.organize = (
 	code,
-	{ filepath = 'file.ts', organizeImportsSkipDestructiveCodeActions, parentParser, parser },
+	{ filepath = 'file.ts', organizeImportsSkipDestructiveCodeActions, parentParser, parser, organizeImportsTypeOrder },
 ) => {
 	if (parentParser === 'vue') {
 		// we already did the preprocessing in the parent parser, so we skip the child parsers
@@ -26,7 +26,7 @@ module.exports.organize = (
 	const fileChanges = languageService.organizeImports(
 		{ type: 'file', fileName: filepath, skipDestructiveCodeActions: organizeImportsSkipDestructiveCodeActions },
 		{},
-		{},
+		{ organizeImportsTypeOrder },
 	)[0];
 
 	return fileChanges ? applyTextChanges(code, fileChanges.textChanges) : code;

--- a/prettier.d.ts
+++ b/prettier.d.ts
@@ -1,9 +1,13 @@
+import ts = require('typescript');
+
 declare module 'prettier' {
 	interface Options {
 		organizeImportsSkipDestructiveCodeActions?: boolean;
+		organizeImportsTypeOrder?: ts.OrganizeImportsTypeOrder;
 	}
 	interface ParserOptions {
 		organizeImportsSkipDestructiveCodeActions?: boolean;
+		organizeImportsTypeOrder?: ts.OrganizeImportsTypeOrder;
 	}
 }
 

--- a/test/main.js
+++ b/test/main.js
@@ -87,3 +87,15 @@ test('does not remove unused imports with `organizeImportsSkipDestructiveCodeAct
 
 	t.is(formattedCode, code);
 });
+
+test('sorts type imports according to the `organizeImportsTypeOrder` option', async (t) => {
+	const code = `import { foo, type baz, bar } from "./foobarbaz";\n\nexport const foobar: baz = foo + bar;\n`;
+
+	const formattedCode1 = await prettify(code, { parser: 'typescript', organizeImportsTypeOrder: 'last' });
+	const formattedCode2 = await prettify(code, { parser: 'typescript', organizeImportsTypeOrder: 'first' });
+	const formattedCode3 = await prettify(code, { parser: 'typescript', organizeImportsTypeOrder: 'inline' });
+
+	t.is(formattedCode1, `import { bar, foo, type baz } from "./foobarbaz";\n\nexport const foobar: baz = foo + bar;\n`);
+	t.is(formattedCode2, `import { type baz, bar, foo } from "./foobarbaz";\n\nexport const foobar: baz = foo + bar;\n`);
+	t.is(formattedCode3, `import { bar, type baz, foo } from "./foobarbaz";\n\nexport const foobar: baz = foo + bar;\n`);
+});


### PR DESCRIPTION
Accepts the `organizeImportsTypeOrder` to be passed on to the typescript language server. Allows choosing where type imports appear when mixed with non-type imports in the same import statement.

Hey nice plugin! i've been using this with a patch for a while, so im opening a PR for it.
This lets you pick how to sort imports like `import { foo, type baz, bar }` into either:
`last`: `import { bar, foo, type baz }`
`first`: `import { type baz, bar, foo }`
`inline`: `import { bar, type baz, foo }`
By default typescript tries to guess what order to use based on what's already in the file, so it can end up being inconsistent across a project.