### PR TITLE
fix: compatibility with prettier-plugin-merge

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,10 +22,7 @@ const organizeImports = (code, options) => {
 		return code;
 	}
 
-	const isRange =
-		Boolean(options.originalText) ||
-		options.rangeStart !== 0 ||
-		(options.rangeEnd !== Infinity && options.rangeEnd !== code.length);
+	const isRange = options.rangeStart !== 0 || options.rangeEnd !== code.length;
 
 	if (isRange) {
 		return code; // processing a range doesn't make sense

--- a/test/main.js
+++ b/test/main.js
@@ -79,6 +79,19 @@ test('skips when formatting a range', async (t) => {
 	t.is(formattedCode2, code);
 });
 
+test('should format when range is entire file', async (t) => {
+	const code = `import { foo, bar } from "./bar";
+
+		export const foobar = foo + bar;`;
+	const expectedImportLine = 'import { bar, foo } from "./bar";';
+
+	const formattedCode1 = await prettify(code, { rangeStart: 0, rangeEnd: code.length });
+	const formattedCode2 = await prettify(code, { originalText: code, rangeStart: 0, rangeEnd: code.length });
+
+	t.is(formattedCode1.split('\n')[0], expectedImportLine);
+	t.is(formattedCode2.split('\n')[0], expectedImportLine);
+});
+
 test('does not remove unused imports with `organizeImportsSkipDestructiveCodeActions` enabled', async (t) => {
 	const code = `import { foo } from "./bar";
 `;


### PR DESCRIPTION
This fixes compatibility with [prettier-plugin-merge](https://github.com/ony3000/prettier-plugin-merge), by accepting `originalText` even if the entire file is formatted.

Closes #155